### PR TITLE
chore: disable major version bump by renovate

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,4 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>owncloud-ci/renovate-presets:docker"]
+  "extends": ["github>owncloud-ci/renovate-presets:docker"],
+  "packageRules": [
+    {
+      "description": "Disable major version update",
+      "matchDatasources": ["docker"],
+      "matchPackagePatterns": ["(amd64|arm32v7|arm64v8)/)?golang"],
+      "major": {
+        "enabled": false
+      }
+    }
+  ]
 }

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -6,9 +6,8 @@
       "description": "Disable major version update",
       "matchDatasources": ["docker"],
       "matchPackagePatterns": ["(amd64|arm32v7|arm64v8)/)?golang"],
-      "major": {
-        "enabled": false
-      }
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
     }
   ]
 }

--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM amd64/golang:alpine@sha256:13919fb9091f6667cb375d5fdf016ecd6d3a5d5995603000d422b04583de4ef9
+FROM amd64/golang:alpine
 
 LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.title="ownCloud CI Go" \

--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM golang:alpine@sha256:13919fb9091f6667cb375d5fdf016ecd6d3a5d5995603000d422b04583de4ef9
+FROM amd64/golang:alpine@sha256:13919fb9091f6667cb375d5fdf016ecd6d3a5d5995603000d422b04583de4ef9
 
 LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.title="ownCloud CI Go" \

--- a/v1.16/Dockerfile.amd64
+++ b/v1.16/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM amd64/golang:1.16-alpine@sha256:69d613a986635e0ee3f1b351131fa689b0dd3570ef9cab8e619a5f1fb939ec56
+FROM amd64/golang:1.16-alpine
 
 LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.title="ownCloud CI Go" \

--- a/v1.16/Dockerfile.amd64
+++ b/v1.16/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine@sha256:69d613a986635e0ee3f1b351131fa689b0dd3570ef9cab8e619a5f1fb939ec56
+FROM amd64/golang:1.16-alpine@sha256:69d613a986635e0ee3f1b351131fa689b0dd3570ef9cab8e619a5f1fb939ec56
 
 LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.title="ownCloud CI Go" \

--- a/v1.17/Dockerfile.amd64
+++ b/v1.17/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM golang:1.17-alpine@sha256:13919fb9091f6667cb375d5fdf016ecd6d3a5d5995603000d422b04583de4ef9
+FROM amd64/golang:1.17-alpine@sha256:13919fb9091f6667cb375d5fdf016ecd6d3a5d5995603000d422b04583de4ef9
 
 LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.title="ownCloud CI Go" \

--- a/v1.17/Dockerfile.amd64
+++ b/v1.17/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM amd64/golang:1.17-alpine@sha256:13919fb9091f6667cb375d5fdf016ecd6d3a5d5995603000d422b04583de4ef9
+FROM amd64/golang:1.17-alpine
 
 LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.title="ownCloud CI Go" \


### PR DESCRIPTION
Manual multi-version management, so get rid of the renovate version bumps.