### PR TITLE
fix tput not found error

### DIFF
--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -9,4 +9,4 @@ LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.url="https://github.com/owncloud-ci/golang" \
   org.opencontainers.image.source="https://github.com/owncloud-ci/golang"
 
-RUN apk add bash make git curl gcc musl-dev libc-dev binutils-gold
+RUN apk add bash make git curl gcc musl-dev libc-dev binutils-gold ncurses

--- a/latest/Dockerfile.arm32v7
+++ b/latest/Dockerfile.arm32v7
@@ -9,4 +9,4 @@ LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.url="https://github.com/owncloud-ci/golang" \
   org.opencontainers.image.source="https://github.com/owncloud-ci/golang"
 
-RUN apk add bash make git curl gcc musl-dev libc-dev binutils-gold
+RUN apk add bash make git curl gcc musl-dev libc-dev binutils-gold ncurses

--- a/latest/Dockerfile.arm64v8
+++ b/latest/Dockerfile.arm64v8
@@ -9,4 +9,4 @@ LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.url="https://github.com/owncloud-ci/golang" \
   org.opencontainers.image.source="https://github.com/owncloud-ci/golang"
 
-RUN apk add bash make git curl gcc musl-dev libc-dev binutils-gold
+RUN apk add bash make git curl gcc musl-dev libc-dev binutils-gold ncurses

--- a/v1.16/Dockerfile.amd64
+++ b/v1.16/Dockerfile.amd64
@@ -9,4 +9,4 @@ LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.url="https://github.com/owncloud-ci/golang" \
   org.opencontainers.image.source="https://github.com/owncloud-ci/golang"
 
-RUN apk add bash make git curl gcc musl-dev libc-dev binutils-gold
+RUN apk add bash make git curl gcc musl-dev libc-dev binutils-gold ncurses

--- a/v1.16/Dockerfile.arm32v7
+++ b/v1.16/Dockerfile.arm32v7
@@ -9,4 +9,4 @@ LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.url="https://github.com/owncloud-ci/golang" \
   org.opencontainers.image.source="https://github.com/owncloud-ci/golang"
 
-RUN apk add bash make git curl gcc musl-dev libc-dev binutils-gold
+RUN apk add bash make git curl gcc musl-dev libc-dev binutils-gold ncurses

--- a/v1.16/Dockerfile.arm64v8
+++ b/v1.16/Dockerfile.arm64v8
@@ -9,4 +9,4 @@ LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.url="https://github.com/owncloud-ci/golang" \
   org.opencontainers.image.source="https://github.com/owncloud-ci/golang"
 
-RUN apk add bash make git curl gcc musl-dev libc-dev binutils-gold
+RUN apk add bash make git curl gcc musl-dev libc-dev binutils-gold ncurses

--- a/v1.17/Dockerfile.amd64
+++ b/v1.17/Dockerfile.amd64
@@ -9,4 +9,4 @@ LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.url="https://github.com/owncloud-ci/golang" \
   org.opencontainers.image.source="https://github.com/owncloud-ci/golang"
 
-RUN apk add bash make git curl gcc musl-dev libc-dev binutils-gold
+RUN apk add bash make git curl gcc musl-dev libc-dev binutils-gold ncurses

--- a/v1.17/Dockerfile.arm32v7
+++ b/v1.17/Dockerfile.arm32v7
@@ -9,4 +9,4 @@ LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.url="https://github.com/owncloud-ci/golang" \
   org.opencontainers.image.source="https://github.com/owncloud-ci/golang"
 
-RUN apk add bash make git curl gcc musl-dev libc-dev binutils-gold
+RUN apk add bash make git curl gcc musl-dev libc-dev binutils-gold ncurses

--- a/v1.17/Dockerfile.arm64v8
+++ b/v1.17/Dockerfile.arm64v8
@@ -9,4 +9,4 @@ LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.url="https://github.com/owncloud-ci/golang" \
   org.opencontainers.image.source="https://github.com/owncloud-ci/golang"
 
-RUN apk add bash make git curl gcc musl-dev libc-dev binutils-gold
+RUN apk add bash make git curl gcc musl-dev libc-dev binutils-gold ncurses


### PR DESCRIPTION
Seen in oCIS CI (eg. https://drone.owncloud.com/owncloud/ocis/8048/2/4):

``` 
1 | + make ci-go-generate
-- | --
2 | bash: line 1: tput: command not found
3 | bash: line 1: tput: command not found
4 | bash: line 1: tput: command not found
5 | bash: line 1: tput: command not found
6 | bash: line 1: tput: command not found
7 | bash: line 1: tput: command not found
8 | bash: line 1: tput: command not found
9 | bash: line 1: tput: command not found
10 | bash: line 1: tput: command not found
```

Ncurses provides `tput` on Alpine

