### PR TITLE
chore: add golang 1.23

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -2,7 +2,8 @@ def main(ctx):
   versions = [
     'latest',
     '1.21',
-    '1.22'
+    '1.22',
+    '1.23'
   ]
 
   arches = [

--- a/v1.23/Dockerfile.amd64
+++ b/v1.23/Dockerfile.amd64
@@ -1,0 +1,19 @@
+FROM amd64/golang:1.23-alpine
+
+LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
+  org.opencontainers.image.title="ownCloud CI Go" \
+  org.opencontainers.image.vendor="ownCloud GmbH" \
+  org.opencontainers.image.authors="ownCloud GmbH" \
+  org.opencontainers.image.description="ownCloud CI Go" \
+  org.opencontainers.image.documentation="https://github.com/owncloud-ci/golang.git" \
+  org.opencontainers.image.url="https://github.com/owncloud-ci/golang" \
+  org.opencontainers.image.source="https://github.com/owncloud-ci/golang"
+
+ARG RETRY_VERSION
+
+# renovate: datasource=github-releases depName=owncloud-ci/retry
+ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
+
+RUN apk add bash make git curl gcc musl-dev libc-dev binutils-gold ncurses grep inotify-tools vips-dev && \
+  curl -SsfL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
+  chmod 755 /usr/local/bin/retry

--- a/v1.23/Dockerfile.arm64v8
+++ b/v1.23/Dockerfile.arm64v8
@@ -1,0 +1,19 @@
+FROM arm64v8/golang:1.23-alpine
+
+LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
+  org.opencontainers.image.title="ownCloud CI Go" \
+  org.opencontainers.image.vendor="ownCloud GmbH" \
+  org.opencontainers.image.authors="ownCloud GmbH" \
+  org.opencontainers.image.description="ownCloud CI Go" \
+  org.opencontainers.image.documentation="https://github.com/owncloud-ci/golang.git" \
+  org.opencontainers.image.url="https://github.com/owncloud-ci/golang" \
+  org.opencontainers.image.source="https://github.com/owncloud-ci/golang"
+
+ARG RETRY_VERSION
+
+# renovate: datasource=github-releases depName=owncloud-ci/retry
+ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
+
+RUN apk add bash make git curl gcc musl-dev libc-dev binutils-gold ncurses grep inotify-tools vips-dev && \
+  curl -SsfL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
+  chmod 755 /usr/local/bin/retry

--- a/v1.23/manifest.tmpl
+++ b/v1.23/manifest.tmpl
@@ -1,0 +1,11 @@
+image: owncloudci/golang:1.23
+manifests:
+  - image: owncloudci/golang:1.23-amd64
+    platform:
+      architecture: amd64
+      os: linux
+  - image: owncloudci/golang:1.23-arm64v8
+    platform:
+      architecture: arm64
+      variant: v8
+      os: linux


### PR DESCRIPTION
So that we have it available when needed.

For now, I didn't touch `latest`